### PR TITLE
Fix: Clips not displaying in v4.0 GUI (issue #26)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,9 @@ runtime
 
 # jetbrains
 .idea
+
+# virtual environments
+.venv/
+
+# claude code
+.claude/

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,12 @@ runtime
 
 # virtual environments
 .venv/
+.build_venv/
 
 # claude code
 .claude/
+
+# pyinstaller build artifacts
+build/
+dist/
+*.spec

--- a/BUGFIX_NOTES.md
+++ b/BUGFIX_NOTES.md
@@ -1,0 +1,126 @@
+# SteamClip v4.0 Bug Fix Notes
+
+**Issue:** [#26 — Clips not displaying after v4.0 update](https://github.com/Nastas95/SteamClip/issues/26)
+**Date:** 2026-03-27
+**Contributors:** bra-khet (investigation, direction, review) and Claude Opus (diagnosis, implementation)
+
+---
+
+Hey Nastas95 and team,
+
+First off — thank you for building SteamClip. It's a genuinely useful tool for the Steam community, and the v4.0 rewrite introduced a lot of solid improvements (the new theme, the media type filtering, the background recording support). We really appreciate the work that went into it.
+
+We ran into the issue described in #26 (clips not showing up after the v4.0 update on Windows) and dug into the root cause. Below is a detailed breakdown of everything we found and changed, written to be easy to review, cherry-pick, or modify as you see fit.
+
+---
+
+## Root Cause Summary
+
+The primary issue is a **signal chain timing problem** during GUI initialization. When `populate_steamid_dirs()` adds items to the Steam ID combo box, Qt fires `currentIndexChanged`, which triggers `on_steamid_selected()` → `filter_media_type()`. At this point the media type combo box still contains its initial items from `__init__`, and one of those items had a **different string** than what `filter_media_type()` checks against. This caused the clip folder list to never be populated.
+
+Several secondary issues compounded the problem, making it harder to diagnose and more likely to silently fail.
+
+---
+
+## Fixes Applied (all in `steamclip.py`)
+
+### Fix 1 — Media type string mismatch (line ~415)
+
+**What:** Changed `"Background Clips"` to `"Background Recordings"` in the `__init__` combo box setup.
+
+**Why:** `filter_media_type()` and `update_media_type_combo()` both use `"Background Recordings"`, but `__init__` used `"Background Clips"`. During the initialization signal chain, if `filter_media_type()` ran before `update_media_type_combo()` had a chance to repopulate the combo, the selected text would be `"Background Clips"` — which matched none of the `if`/`elif` branches. Since there was no `else` clause (see Fix 2), `self.clip_folders` was never assigned.
+
+**How we found it:** Compared every string literal used for media type filtering across `__init__`, `update_media_type_combo()`, and `filter_media_type()`. The TEST file (`steamclip_TEST.py`) already used the correct string.
+
+---
+
+### Fix 2 — Missing `else` clause in `filter_media_type()` (line ~871)
+
+**What:** Added a default `else` branch that falls back to showing all clips and logs a warning.
+
+**Why:** Without an `else`, any unrecognized media type string (including the typo from Fix 1, or an empty combo state during initialization) would silently leave `self.clip_folders` as whatever it was before — typically `[]` from `__init__`. This made the bug completely silent: no errors, no warnings, just an empty grid.
+
+---
+
+### Fix 3 — `filter_media_type()` call outside `finally` block (line ~957)
+
+**What:** Moved `self.filter_media_type()` from after the `try`/`finally` in `update_media_type_combo()` to inside the `finally` block.
+
+**Why:** If the `try` block hit an early `return` (e.g., when `selected_steamid` was empty), the `finally` block correctly unblocked signals, but `filter_media_type()` — which is the sole entry point for clip discovery — was never called. This meant clips would not load on certain code paths. The TEST version already had this call inside `finally`.
+
+**How we found it:** Side-by-side comparison of `update_media_type_combo()` in `steamclip.py` vs `steamclip_TEST.py`.
+
+---
+
+### Fix 4 — `clear_clip_grid()` not properly draining the layout (line ~873)
+
+**What:** Changed from iterating with `range(count)` + `deleteLater()` to a `while count()` loop using `takeAt(0)` + `setParent(None)` + `deleteLater()`.
+
+**Why:** `deleteLater()` defers widget destruction to the next event loop cycle. Without removing items from the layout first, repeated calls to `display_clips()` during init (triggered by the signal chain) accumulated invisible stale widgets in the grid. The old approach also iterated forward while the count was changing, which is unreliable. The new approach properly drains the layout.
+
+---
+
+### Fix 5 — `extract_datetime_from_folder_name()` splitting full paths (line ~946)
+
+**What:** Added `os.path.basename(folder_path)` before splitting by `_`.
+
+**Why:** The function received full paths like `C:\Program Files (x86)\Steam\userdata\12345\gamerecordings\clips\clip_730_20260327_120000` and split the entire string by `_`. This happened to work on default Steam paths (no underscores in parent directories), but would break on any custom path containing underscores (e.g., `D:\My_Games\Steam\...`). Using `basename()` isolates just the folder name before parsing.
+
+---
+
+### Fix 6 — `populate_gameid_combo()` splitting full paths (line ~957)
+
+**What:** Changed `folder.split('_')[1]` to `os.path.basename(folder).split('_')[1]` with a guard for folders containing `_`.
+
+**Why:** Same root cause as Fix 5. Extracting game IDs from full paths is fragile. The `if '_' in os.path.basename(folder)` guard also prevents `IndexError` on malformed folder names.
+
+---
+
+### Fix 7 — `SettingsWindow.update_game_ids()` splitting full paths (line ~1578)
+
+**What:** Same `basename()` fix applied to the Settings window's game ID extraction.
+
+**Why:** This code path was independently parsing folder names with the same fragile pattern. Kept in sync with Fix 6.
+
+---
+
+### Fix 8 — Thumbnail fallback for read-only clip directories (line ~1064)
+
+**What:** Added a fallback that creates placeholder thumbnails in the system temp directory when the clip folder itself isn't writable.
+
+**Why:** If `extract_first_frame()` and `create_placeholder_thumbnail()` both failed (e.g., because the Steam directory has restricted write permissions), the clip was silently dropped from the display grid. Now there's a last-resort fallback, and a log warning if even that fails.
+
+---
+
+### Fix 9 — HTTP request timeout for Steam API calls (line ~693)
+
+**What:** Added `timeout=5` to `requests.get()` in `fetch_game_name_from_steam()`.
+
+**Why:** This function is called synchronously for each unknown game ID during `populate_gameid_combo()`. Without a timeout, a slow or unreachable Steam API would freeze the entire GUI indefinitely, preventing clips from ever appearing.
+
+---
+
+### Fix 10 — Diagnostic logging in `filter_media_type()` (lines ~856–870)
+
+**What:** Added logging for each directory scan showing the path checked and folder count found.
+
+**Why:** The original code had minimal logging in this critical function. When clips fail to load, these logs immediately reveal which directories were checked and whether any folders were found, making future debugging much faster.
+
+---
+
+## How to Verify
+
+1. Launch SteamClip with valid clips in the default Steam directory
+2. Clips should appear in the grid immediately after selecting a Steam ID
+3. Switch between "All Clips", "Manual Clips", and "Background Recordings" — each should filter correctly
+4. Check the log output for the new diagnostic lines showing directory scan results
+
+## Files Changed
+
+- `steamclip.py` — 101 insertions, 9 deletions (all fixes + inline documentation)
+
+---
+
+Thanks again for SteamClip — happy to discuss any of these changes or adjust the approach. Hope this helps!
+
+— bra-khet & Claude Opus

--- a/steamclip.py
+++ b/steamclip.py
@@ -412,7 +412,15 @@ class SteamClipApp(QWidget):
         self.steamid_combo.setFixedSize(300, 40)
         self.gameid_combo.setFixedSize(300, 40)
         self.media_type_combo.setFixedSize(300, 40)
-        self.media_type_combo.addItems(["All Clips", "Manual Clips", "Background Clips"])
+        # BUG FIX: media_type_string_mismatch
+        # Fix: Was "Background Clips" here but "Background Recordings" everywhere else
+        #   (update_media_type_combo, filter_media_type). If filter_media_type() ran before
+        #   update_media_type_combo() repopulated this combo, selecting the third item would
+        #   yield "Background Clips" which matched NONE of the elif branches, causing
+        #   self.clip_folders to never be assigned from the local video_folders variable.
+        # Sync: update_media_type_combo() and filter_media_type() must use identical strings.
+        # (Diagnosed and fixed by Claude at the behest of user "bra-keht", 2026-03-27)
+        self.media_type_combo.addItems(["All Clips", "Manual Clips", "Background Recordings"])
         self.media_type_combo.setCurrentIndex(0)
         self.steamid_combo.currentIndexChanged.connect(self.on_steamid_selected)
         self.gameid_combo.currentIndexChanged.connect(self.filter_clips_by_gameid)
@@ -691,7 +699,11 @@ class SteamClipApp(QWidget):
     def fetch_game_name_from_steam(self, game_id):
         url = f"{self.STEAM_APP_DETAILS_URL}?appids={game_id}&filters=basic"
         try:
-            response = requests.get(url)
+            # CHANGED: Added timeout=5 to prevent indefinite blocking of the UI thread
+            # WHY: populate_gameid_combo() calls this synchronously for each unknown game ID.
+            #   Without a timeout, a slow/unreachable Steam API would freeze the entire GUI,
+            #   preventing clips from ever being displayed.
+            response = requests.get(url, timeout=5)
             response.raise_for_status()
             logger(f"Fetched game name for ID {game_id}")
             data = response.json()
@@ -834,6 +846,7 @@ class SteamClipApp(QWidget):
             self.prev_media_type = selected_media_type
         selected_steamid = self.steamid_combo.currentText()
         if not selected_steamid:
+            logger("filter_media_type: no steamid selected, returning early.")
             return
         userdata_dir = os.path.join(self.default_dir, selected_steamid)
         custom_record_path = self.get_custom_record_path(userdata_dir)
@@ -843,23 +856,44 @@ class SteamClipApp(QWidget):
         video_dir_custom = os.path.join(custom_record_path, 'video') if custom_record_path else None
         clip_folders = []
         video_folders = []
+        # CHANGED: Added diagnostic logging for each directory scan path
+        # WHY: When clips fail to load, these logs reveal which directories were checked
+        #   and how many folders were found, making it easy to pinpoint the failure stage.
         if os.path.isdir(clips_dir_default):
             clip_folders.extend(folder.path for folder in os.scandir(clips_dir_default) if folder.is_dir() and "_" in folder.name)
+            logger(f"  Scanned clips_dir_default: {clips_dir_default} -> {len(clip_folders)} folders")
+        else:
+            logger(f"  clips_dir_default does not exist: {clips_dir_default}")
         if os.path.isdir(video_dir_default):
             video_folders.extend(folder.path for folder in os.scandir(video_dir_default) if folder.is_dir() and "_" in folder.name)
+            logger(f"  Scanned video_dir_default: {video_dir_default} -> {len(video_folders)} folders")
+        else:
+            logger(f"  video_dir_default does not exist: {video_dir_default}")
         if clips_dir_custom and os.path.isdir(clips_dir_custom):
             clip_folders.extend(folder.path for folder in os.scandir(clips_dir_custom) if folder.is_dir() and "_" in folder.name)
+            logger(f"  Scanned clips_dir_custom: {clips_dir_custom} -> {len(clip_folders)} folders")
         if video_dir_custom and os.path.isdir(video_dir_custom):
             video_folders.extend(folder.path for folder in os.scandir(video_dir_custom) if folder.is_dir() and "_" in folder.name)
+            logger(f"  Scanned video_dir_custom: {video_dir_custom} -> {len(video_folders)} folders")
         if selected_media_type == "All Clips":
             self.clip_folders = clip_folders + video_folders
         elif selected_media_type == "Manual Clips":
             self.clip_folders = clip_folders
         elif selected_media_type == "Background Recordings":
             self.clip_folders = video_folders
+        else:
+            # BUG FIX: filter_media_type_missing_default
+            # Fix: If selected_media_type was empty (combo cleared) or did not match any
+            #   known value (e.g. the old "Background Clips" typo from __init__ line 415),
+            #   self.clip_folders was never assigned from the local clip_folders/video_folders
+            #   variables. It retained its previous value — often [] from __init__. This caused
+            #   zero clips to be displayed with zero errors. Default to showing all clips.
+            # (Diagnosed and fixed by Claude at the behest of user "bra-keht", 2026-03-27)
+            logger(f"WARNING: Unrecognized media type '{selected_media_type}', defaulting to all clips.")
+            self.clip_folders = clip_folders + video_folders
         self.clip_folders = sorted(self.clip_folders, key=lambda x: self.extract_datetime_from_folder_name(x), reverse=True)
         self.original_clip_folders = list(self.clip_folders)
-        logger(f"Media filter applied. Found {len(self.clip_folders)} clips total.")
+        logger(f"Media filter applied. Found {len(self.clip_folders)} clips total (type='{selected_media_type}').")
         self.populate_gameid_combo()
         self.display_clips()
 
@@ -871,9 +905,20 @@ class SteamClipApp(QWidget):
         self.filter_media_type()
 
     def clear_clip_grid(self):
-        for i in range(self.clip_grid.count()):
-            widget = self.clip_grid.itemAt(i).widget()
+        # BUG FIX: clip_grid_clear_stale_widgets
+        # Fix: Previously used deleteLater() without removing items from the layout.
+        #   When display_clips() was called multiple times during init (via signal chains
+        #   from populate_steamid_dirs -> on_steamid_selected -> filter_media_type), widgets
+        #   accumulated in the grid because deleteLater() defers deletion to the next event
+        #   loop cycle. Now we drain the layout properly by removing items in reverse order
+        #   and then deleting the widgets.
+        # Sync: display_clips() relies on this grid being truly empty before adding new widgets.
+        # (Diagnosed and fixed by Claude at the behest of user "bra-keht", 2026-03-27)
+        while self.clip_grid.count():
+            item = self.clip_grid.takeAt(0)
+            widget = item.widget()
             if widget:
+                widget.setParent(None)
                 widget.deleteLater()
 
     def clear_selection(self):
@@ -912,6 +957,14 @@ class SteamClipApp(QWidget):
         self.update_media_type_combo()
 
     def update_media_type_combo(self):
+        # BUG FIX: filter_media_type_skipped_on_early_return
+        # Fix: self.filter_media_type() was OUTSIDE the try/finally block. If the try block
+        #   hit the early 'return' (when selected_steamid was empty), the finally block ran
+        #   (unblocking signals) but filter_media_type() was NEVER called — meaning clips
+        #   were never loaded on that code path. Moved filter_media_type() inside the finally
+        #   block so it ALWAYS executes, matching the TEST version's behavior.
+        # Sync: filter_media_type() is the sole entry point for clip discovery and display.
+        # (Diagnosed and fixed by Claude at the behest of user "bra-keht", 2026-03-27)
         self.media_type_combo.blockSignals(True)
         try:
             selected_steamid = self.steamid_combo.currentText()
@@ -930,10 +983,18 @@ class SteamClipApp(QWidget):
             self.media_type_combo.setCurrentIndex(0)
         finally:
             self.media_type_combo.blockSignals(False)
-        self.filter_media_type()
+            self.filter_media_type()
 
     @staticmethod
-    def extract_datetime_from_folder_name(folder_name):
+    def extract_datetime_from_folder_name(folder_path):
+        # BUG FIX: datetime_extraction_uses_basename
+        # Fix: Previously split the full path by '_', which worked by accident on default
+        #   Steam paths (no underscores in parent directories) but was fragile and would
+        #   break if Steam was installed in a path containing underscores (e.g. D:\My_Games\).
+        #   Now uses os.path.basename() to isolate the folder name before splitting.
+        # Sync: populate_gameid_combo() and filter_clips_by_gameid() also parse folder names.
+        # (Diagnosed and fixed by Claude at the behest of user "bra-keht", 2026-03-27)
+        folder_name = os.path.basename(folder_path)
         parts = folder_name.split('_')
         if len(parts) >= 3:
             try:
@@ -945,7 +1006,19 @@ class SteamClipApp(QWidget):
 
     def populate_gameid_combo(self):
         folders_source = self.original_clip_folders if self.original_clip_folders else self.clip_folders
-        game_ids_in_clips = {folder.split('_')[1] for folder in folders_source}
+        # BUG FIX: gameid_extraction_from_full_path
+        # Fix: Previously did folder.split('_')[1] on the FULL file path, which only worked
+        #   when the parent directory path contained no underscores. On default Windows Steam
+        #   paths (C:\Program Files (x86)\Steam\...) this happened to work, but was unreliable.
+        #   If the clip folder naming convention is {prefix}_{gameid}_{date}_{time}, index [1]
+        #   on the basename is the game ID. If it's {gameid}_{date}_{time} (no prefix), index [0]
+        #   would be the game ID — but the existing convention expected index [1].
+        #   Now uses os.path.basename() to parse only the folder name, not the full path.
+        # Sync: extract_datetime_from_folder_name(), filter_clips_by_gameid(), update_game_ids()
+        #   in SettingsWindow, and generate_output_filename() in ConversionThread all parse folder
+        #   names and must agree on the naming convention.
+        # (Diagnosed and fixed by Claude at the behest of user "bra-keht", 2026-03-27)
+        game_ids_in_clips = {os.path.basename(folder).split('_')[1] for folder in folders_source if '_' in os.path.basename(folder)}
         sorted_game_ids = sorted(game_ids_in_clips)
 
         current_id = self.gameid_combo.currentData()
@@ -1004,8 +1077,25 @@ class SteamClipApp(QWidget):
             thumbnail_path = os.path.join(folder, 'thumbnail.jpg')
             if first_session_mpd and not os.path.exists(thumbnail_path):
                 self.extract_first_frame(first_session_mpd, thumbnail_path)
+            # BUG FIX: silent_clip_drop_on_thumbnail_failure
+            # Fix: Previously, if both extract_first_frame() and create_placeholder_thumbnail()
+            #   failed (e.g. due to write permissions on the Steam directory), the clip was
+            #   silently dropped from the grid — no thumbnail meant no widget. Now we always
+            #   attempt to create a placeholder in a writable temp location as a last resort,
+            #   and always add the clip to the grid so the user can still see and select it.
+            # (Diagnosed and fixed by Claude at the behest of user "bra-keht", 2026-03-27)
+            if not os.path.exists(thumbnail_path):
+                try:
+                    fallback_path = os.path.join(tempfile.gettempdir(), f"steamclip_thumb_{index}.jpg")
+                    self.create_placeholder_thumbnail(fallback_path)
+                    if os.path.exists(fallback_path):
+                        thumbnail_path = fallback_path
+                except Exception as exc:
+                    logger(f"Last-resort placeholder also failed for {folder}: {exc}")
             if os.path.exists(thumbnail_path):
                 self.add_thumbnail_to_grid(thumbnail_path, folder, index)
+            else:
+                logger(f"WARNING: Could not create any thumbnail for clip: {folder}")
         placeholders_needed = 6 - len(clips_to_show)
         for i in range(placeholders_needed):
             placeholder = QFrame()
@@ -1544,7 +1634,9 @@ class SettingsWindow(QDialog):
                 logger("Update GameIDs failed: No internet connection.")
                 return QMessageBox.warning(self, "Warning", "No internet connection")
 
-            game_ids = {folder.split('_')[1] for folder in self.parent().original_clip_folders}
+            # CHANGED: Use os.path.basename() before splitting — see populate_gameid_combo() fix
+            # WHY: Splitting full paths by '_' extracts wrong values if path contains underscores
+            game_ids = {os.path.basename(folder).split('_')[1] for folder in self.parent().original_clip_folders if '_' in os.path.basename(folder)}
             updated = False
             logger(f"Checking GameIDs for {len(game_ids)} games...")
 


### PR DESCRIPTION
## Summary

Fixes #26 — clips not showing up in the GUI after updating to v4.0, despite the app correctly resolving clip directories (e.g., detecting and deleting corrupt clips during config).

**Root cause:** A signal chain timing issue during GUI initialization. When `populate_steamid_dirs()` adds items to the Steam ID combo box, Qt fires `currentIndexChanged` which triggers `filter_media_type()` before `update_media_type_combo()` has repopulated the media type dropdown. A string mismatch (`"Background Clips"` in `__init__` vs `"Background Recordings"` everywhere else) combined with a missing `else` fallback caused `self.clip_folders` to silently remain `[]`.

## Changes

- **String mismatch fix** — Corrected `"Background Clips"` → `"Background Recordings"` in `__init__` to match `update_media_type_combo()` and `filter_media_type()`
- **Missing else clause** — Added default fallback in `filter_media_type()` so unrecognized media types show all clips instead of silently showing none
- **`filter_media_type()` placement** — Moved from outside `try/finally` to inside `finally` block in `update_media_type_combo()`, so clip discovery always runs (matches `steamclip_TEST.py` behavior)
- **`clear_clip_grid()` fix** — Changed from forward iteration with `deleteLater()` to proper `takeAt(0)` drain loop, preventing stale widget accumulation during init signal chains
- **Path parsing robustness** — Added `os.path.basename()` before `split('_')` in `extract_datetime_from_folder_name()`, `populate_gameid_combo()`, and `SettingsWindow.update_game_ids()` so they work on paths containing underscores
- **Thumbnail fallback** — Added temp directory fallback for placeholder thumbnails when clip directories aren't writable
- **API timeout** — Added `timeout=5` to `requests.get()` in `fetch_game_name_from_steam()` to prevent indefinite UI freezes
- **Diagnostic logging** — Added directory scan logging in `filter_media_type()` for easier future debugging
- **`.gitignore`** — Added `.venv/` and `.claude/`

Full per-fix breakdown with rationale is in [`BUGFIX_NOTES.md`](https://github.com/bra-khet/SteamClip/blob/fix/clip-display-issue-26/BUGFIX_NOTES.md).

## Test Plan

- [x] Launch SteamClip with valid clips in default Steam directory — clips appear immediately
- [x] Switch between "All Clips", "Manual Clips", and "Background Recordings" — each filters correctly
- [x] Verified on Windows 10 with standard Steam installation path
- [ ] Test with custom Steam library paths containing underscores
- [ ] Test with Steam API unreachable (should timeout gracefully after 5s)

## Attribution

This fix was a collaboration between **bra-khet** (investigation, direction, testing) and **Claude Opus** (diagnosis, implementation). Thank you for building SteamClip — it's a great tool for the community, and we hope this helps!

🤖 Generated with [Claude Code](https://claude.ai/code)